### PR TITLE
fix: return classnames and use in new component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "blank-scss",
       "version": "0.1.0",
       "dependencies": {
+        "classnames": "^2.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "web-vitals": "^3.1.1"
@@ -5860,6 +5861,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.1",
@@ -22271,6 +22277,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-css": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "classnames": "^2.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^3.1.1"

--- a/src/_codux/component-templates/default/new-component.tsx
+++ b/src/_codux/component-templates/default/new-component.tsx
@@ -1,9 +1,9 @@
 import styles from './new-component.module.scss';
-
+import classNames from 'classnames';
 export interface NewComponentProps {
     className?: string;
 }
 
 export const NewComponent = ({ className }: NewComponentProps) => {
-    return <div className={`${styles.root} ${className}`}>NewComponent</div>;
+    return <div className={classNames(styles.root, className)}>NewComponent</div>;
 };


### PR DESCRIPTION
This is the opposite commit to https://github.com/codux-templates/blank-scss/commit/a7521f4d3939c23240a7b78b91b2728fd86a3f50 and it is written according to this doc: https://docs.google.com/document/d/1gVIo8zQSl6BhcX5P0CspTOE75HTY-NGu0_z7U4h1BhY/edit#heading=h.6hk3ix25jnrt