### PR TITLE
Omer/template change

### DIFF
--- a/src/_codux/component-templates/default/new-component.tsx
+++ b/src/_codux/component-templates/default/new-component.tsx
@@ -6,8 +6,8 @@ export interface NewComponentProps {
 }
 
 /**
- * This component was generated using Codux's built-in Default new component template.
- * For details on how to create custom new component templates, see https://help.codux.com/kb/en/article/configuration-for-new-components-and-templates
+ * This component was created using Codux's Default new component template.
+ * To create custom component templates, see https://help.codux.com/kb/en/article/configuration-for-new-components-and-templates
  */
 export const NewComponent = ({ className }: NewComponentProps) => {
     return <div className={classNames(styles.root, className)}>NewComponent</div>;

--- a/src/_codux/component-templates/default/new-component.tsx
+++ b/src/_codux/component-templates/default/new-component.tsx
@@ -3,13 +3,12 @@ import classNames from 'classnames';
 
 export interface NewComponentProps {
     className?: string;
-    children?: React.ReactNode;
 }
 
 /**
  * This component was generated using Codux's built-in Default new component template.
  * For details on how to create custom new component templates, see https://help.codux.com/kb/en/article/configuration-for-new-components-and-templates
  */
-export const NewComponent = ({ className, children = 'NewComponent' }: NewComponentProps) => {
-    return <div className={classNames(styles.root, className)}>{children}</div>;
+export const NewComponent = ({ className }: NewComponentProps) => {
+    return <div className={classNames(styles.root, className)}>NewComponent</div>;
 };


### PR DESCRIPTION
Replaced the default new-component-template to use a simple text-node that shows the name of the component (instead of passing it as `children` with default value)